### PR TITLE
Support arbitrary fairs based on the incoming route

### DIFF
--- a/app/collections/shows.coffee
+++ b/app/collections/shows.coffee
@@ -5,7 +5,8 @@ Show        = require '../models/show'
 module.exports = class Shows extends Collection
   model: Show
 
-  url: "#{config.API_ROOT}/fair/#{config.FAIR_ID}/shows"
+  url: ->
+    "#{config.API_ROOT}/fair/#{config.FAIR_ID}/shows"
 
   parse: (response) ->
     response.results

--- a/app/models/boards.coffee
+++ b/app/models/boards.coffee
@@ -5,25 +5,25 @@ class TrendingArtists extends Board
   initialize: ->
     super
     @set id: 'trending-artists', name: 'Trending Artists'
-    @trending.url     = "#{config.API_ROOT}/fair/#{config.FAIR_ID}/trending/artists?size=10"
-    @trending.entity  = 'artist'
+    @trending.url = -> "#{config.API_ROOT}/fair/#{config.FAIR_ID}/trending/artists?size=10"
+    @trending.entity = 'artist'
 
 class TrendingExhibitors extends Board
   initialize: ->
     super
     @set id: 'trending-exhibitors', name: 'Trending Exhibitors'
-    @trending.url     = "#{config.API_ROOT}/fair/#{config.FAIR_ID}/trending/partners?size=10"
-    @trending.entity  = 'partner'
+    @trending.url = -> "#{config.API_ROOT}/fair/#{config.FAIR_ID}/trending/partners?size=10"
+    @trending.entity = 'partner'
 
 
 class FollowedExhibitors extends Board
   initialize: ->
     super
     @set id: 'followed-exhibitors', name: 'Most Followed Exhibitors'
-    @trending.url     = "#{config.API_ROOT}/fair/#{config.FAIR_ID}/partners/follows?size=10"
-    @trending.entity  = 'partner'
+    @trending.url = -> "#{config.API_ROOT}/fair/#{config.FAIR_ID}/partners/follows?size=10"
+    @trending.entity = 'partner'
 
 module.exports =
-  TrendingArtists: TrendingArtists
-  TrendingExhibitors: TrendingExhibitors
-  FollowedExhibitors: FollowedExhibitors
+  TrendingArtists    : TrendingArtists
+  TrendingExhibitors : TrendingExhibitors
+  FollowedExhibitors : FollowedExhibitors

--- a/app/models/feed.coffee
+++ b/app/models/feed.coffee
@@ -2,4 +2,5 @@ config  = require '../config/config'
 Model   = require '../core/model'
 
 module.exports = class Feed extends Model
-  url: "#{config.API_ROOT}/fair/#{config.FAIR_ID}/feed"
+  url: ->
+    "#{config.API_ROOT}/fair/#{config.FAIR_ID}/feed"

--- a/app/routers/router.coffee
+++ b/app/routers/router.coffee
@@ -3,12 +3,13 @@ application       = require '../application'
 HomeView          = require '../views/home'
 LeaderboardView   = require '../views/leaderboard'
 MapView           = require '../views/map'
+config            = require 'config/config'
 
 module.exports = class ApplicationRouter extends Router
   routes:
-    ''            : 'home'
-    'leaderboard' : 'leaderboard'
-    'map'         : 'map'
+    ''                : 'home'
+    ':id/leaderboard' : 'leaderboard'
+    ':id/map'         : 'map'
 
   initialize: ->
     $(window).on 'keyup', @toggleCursor
@@ -25,10 +26,12 @@ module.exports = class ApplicationRouter extends Router
     @view = new HomeView
     $('body').html @view.render().$el
 
-  leaderboard: ->
+  leaderboard: (id) ->
+    config.FAIR_ID = id
     @view = new LeaderboardView
     $('body').html @view.render().$el
 
-  map: ->
+  map: (id) ->
+    config.FAIR_ID = id
     @view = new MapView
     $('body').html @view.render().$el


### PR DESCRIPTION
Adds support for other fairs by setting `config.FAIR_ID`. Makes more sense for this to be global rather than passed around. Relevant `url` properties are changed to functions so that they have the correct value at runtime.
